### PR TITLE
Timer audio fix

### DIFF
--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -1,0 +1,15 @@
+enum AudioStatus { playing, paused, stopped }
+
+abstract class AudioService {
+  Future<void> configure() async {
+    // Default no-op implementation
+  }
+  Future<void> play();
+  Future<void> pause();
+  Future<void> resume();
+  Future<void> stop();
+  Future<void> dispose();
+
+  AudioStatus get status;
+  set status(AudioStatus value);
+}

--- a/lib/services/timer_audio_service.dart
+++ b/lib/services/timer_audio_service.dart
@@ -16,10 +16,6 @@ class TimerAudioService extends AudioService{
         usageType: AndroidUsageType.notification,
         audioFocus: AndroidAudioFocus.gainTransientMayDuck,
       ),
-      iOS: AudioContextIOS(
-        category: AVAudioSessionCategory.playback,
-        options: {AVAudioSessionOptions.mixWithOthers},
-      ),
     ));
   }
 

--- a/lib/services/timer_audio_service.dart
+++ b/lib/services/timer_audio_service.dart
@@ -1,0 +1,64 @@
+import 'package:audioplayers/audioplayers.dart';
+import 'package:count_up/services/audio_service.dart';
+
+class TimerAudioService extends AudioService{
+  AudioPlayer _player = AudioPlayer();
+  AudioStatus _status = AudioStatus.stopped;
+  final AssetSource _asset;
+
+  TimerAudioService(String assetPath) : _asset = AssetSource(assetPath);
+
+  // Configures player to duck other audio during playback
+  @override
+  Future<void> configure() async {
+    await _player.setAudioContext(AudioContext(
+      android: AudioContextAndroid(
+        usageType: AndroidUsageType.notification,
+        audioFocus: AndroidAudioFocus.gainTransientMayDuck,
+      ),
+      iOS: AudioContextIOS(
+        category: AVAudioSessionCategory.playback,
+        options: {AVAudioSessionOptions.mixWithOthers},
+      ),
+    ));
+  }
+
+	@override
+  Future<void> play() async {
+    await _player.play(_asset);
+    _status = AudioStatus.playing;
+  }
+
+	@override
+  Future<void> pause() async {
+    if (_status == AudioStatus.playing) {
+      await _player.pause();
+      _status = AudioStatus.paused;
+    }
+  }
+
+	@override
+  Future<void> resume() async {
+    if (_status == AudioStatus.paused) {
+      await _player.resume();
+      _status = AudioStatus.playing;
+    }
+  }
+
+	@override
+  Future<void> stop() async {
+    await _player.stop();
+    _status = AudioStatus.stopped;
+  }
+
+  Future<void> dispose() async{
+    await _player.dispose();
+  }
+
+  AudioStatus get status => _status;
+
+	@override
+  set status(AudioStatus value) {
+    _status = value;
+  }
+}

--- a/lib/state/timer_provider.dart
+++ b/lib/state/timer_provider.dart
@@ -117,13 +117,13 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
     }
   }
 
-  Future<void> stopSoundIfPlaying() async {
+  Future<void> stopSound() async {
     _audioStatus = AudioStatus.stopped;
     await widget.player.stop();
   }
 
   Future<void> goPrevious() async {
-    await stopSoundIfPlaying();
+    await stopSound();
 
     if (widget.duration.inSeconds - _timeLeft.inSeconds > 2) {
       restartTimer();
@@ -140,7 +140,7 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
   }
 
   Future<void> goNext() async {
-    await stopSoundIfPlaying();
+    await stopSound();
     _timer.cancel();
     _controller.stop();
     widget.nextExercise(null);
@@ -178,7 +178,7 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
   void dispose() {
     _timer.cancel();
     _controller.dispose();
-    stopSoundIfPlaying();
+    stopSound();
     super.dispose();
   }
 

--- a/lib/state/timer_provider.dart
+++ b/lib/state/timer_provider.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
 import 'package:count_up/widgets/timer_widget.dart';
 import 'package:flutter/material.dart';
-import 'package:audioplayers/audioplayers.dart';
-
-enum AudioStatus { playing, paused, stopped }
+import 'package:count_up/services/audio_service.dart';
 
 class TimerProvider extends StatefulWidget {
   final Duration duration;
@@ -14,7 +12,7 @@ class TimerProvider extends StatefulWidget {
   final int noOfExercises;
   final ValueChanged<void> nextExercise;
   final ValueChanged<void> previousExercise;
-  final AudioPlayer player;
+  final AudioService player;
   const TimerProvider(
       {Key? key,
       required this.name,
@@ -33,12 +31,10 @@ class TimerProvider extends StatefulWidget {
 
 class _TimerProviderState extends State<TimerProvider> with SingleTickerProviderStateMixin {
   final String audioPath = "audio/exercise_change.mp3";
-  final AssetSource audioAsset = AssetSource("audio/exercise_change.mp3");
   late Timer _timer;
   late Duration _timeLeft;
   late AnimationController _controller;
   bool _isPaused = false;
-  AudioStatus _audioStatus = AudioStatus.stopped;
   var oneSec = Duration(seconds: 1);
   @override
   void initState() {
@@ -49,7 +45,7 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
       duration: widget.duration + oneSec,
     )..addListener(() {
         setState(() {});
-      });
+    });
     startTimer();
   }
 
@@ -59,11 +55,11 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
       setState(() {
         _timeLeft -= Duration(seconds: 1);
         if (_timeLeft.inSeconds == 3) {
-          playSound();
+        	widget.player.play();
         }
         if (_timeLeft.inSeconds <= -1) {
           timer.cancel();
-          _audioStatus = AudioStatus.stopped;
+          widget.player.status = AudioStatus.stopped;
           widget.nextExercise(null);
         }
       });
@@ -73,13 +69,13 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
   Future<void> pauseTimer() async {
     _timer.cancel();
     _controller.stop();
-    await pauseSoundIfPlaying();
+    await widget.player.pause();
   }
 
   Future<void> resumeTimer() async {
     startTimer();
     _controller.forward(from: _controller.value);
-    await resumeSoundIfPaused();
+    await widget.player.resume();
   }
 
   Future<void> restartTimer() async {
@@ -98,32 +94,8 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
     }
   }
 
-  Future<void> playSound() async {
-    await widget.player.play(audioAsset);
-    _audioStatus = AudioStatus.playing;
-  }
-
-  Future<void> pauseSoundIfPlaying() async {
-    if (_audioStatus == AudioStatus.playing) {
-      _audioStatus = AudioStatus.paused;
-      await widget.player.pause();
-    }
-  }
-
-  Future<void> resumeSoundIfPaused() async {
-    if (_audioStatus == AudioStatus.paused) {
-      _audioStatus = AudioStatus.playing;
-      await widget.player.resume();
-    }
-  }
-
-  Future<void> stopSound() async {
-    _audioStatus = AudioStatus.stopped;
-    await widget.player.stop();
-  }
-
   Future<void> goPrevious() async {
-    await stopSound();
+    await widget.player.stop();
 
     if (widget.duration.inSeconds - _timeLeft.inSeconds > 2) {
       restartTimer();
@@ -140,7 +112,7 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
   }
 
   Future<void> goNext() async {
-    await stopSound();
+    await widget.player.stop();
     _timer.cancel();
     _controller.stop();
     widget.nextExercise(null);
@@ -178,7 +150,7 @@ class _TimerProviderState extends State<TimerProvider> with SingleTickerProvider
   void dispose() {
     _timer.cancel();
     _controller.dispose();
-    stopSound();
+    widget.player.stop();
     super.dispose();
   }
 

--- a/lib/state/workout_provider.dart
+++ b/lib/state/workout_provider.dart
@@ -74,20 +74,20 @@ class _WorkoutProviderState extends State<WorkoutProvider> {
   @override
   Widget build(BuildContext context) {
     return Center(
-        child: _isWorkoutComplete
-            ? WorkoutComplete(
-                restartWorkout: restartWorkout,
-              )
-            : TimerProvider(
-                name: _exercises[_currentIndex].name,
-                nextName: _currentIndex < _exercises.length - 1 ? _exercises[_currentIndex + 1].name : null,
-                duration: Duration(seconds: _exercises[_currentIndex].duration),
-                currentIndex: _currentIndex,
-                nextExercise: nextExercise,
-                previousExercise: previousExercise,
-                noOfExercises: _exercises.length - 1,
-                workoutProgress: "${_currentIndex + 1}/${_exercises.length}",
+			child: _isWorkoutComplete
+				? WorkoutComplete(
+						restartWorkout: restartWorkout,
+					)
+				: TimerProvider(
+						name: _exercises[_currentIndex].name,
+						nextName: _currentIndex < _exercises.length - 1 ? _exercises[_currentIndex + 1].name : null,
+						duration: Duration(seconds: _exercises[_currentIndex].duration),
+						currentIndex: _currentIndex,
+						nextExercise: nextExercise,
+						previousExercise: previousExercise,
+						noOfExercises: _exercises.length - 1,
+						workoutProgress: "${_currentIndex + 1}/${_exercises.length}",
 						player: player,
-              ));
-  }
+					));
+	}
 }

--- a/lib/state/workout_provider.dart
+++ b/lib/state/workout_provider.dart
@@ -67,6 +67,7 @@ class _WorkoutProviderState extends State<WorkoutProvider> {
 
   @override
   void dispose() {
+		player.dispose();
     super.dispose();
   }
 

--- a/lib/state/workout_provider.dart
+++ b/lib/state/workout_provider.dart
@@ -1,8 +1,9 @@
-import 'package:audioplayers/audioplayers.dart';
 import 'package:flutter/material.dart';
 import '../models/exercise.dart';
 import './timer_provider.dart';
 import '../widgets/workout_complete.dart';
+import '../services/audio_service.dart';
+import '../services/timer_audio_service.dart';
 
 class WorkoutProvider extends StatefulWidget {
   final List<Exercise> exercises;
@@ -16,28 +17,19 @@ class _WorkoutProviderState extends State<WorkoutProvider> {
   List<Exercise> _exercises = [];
   int _currentIndex = 0;
   bool _isWorkoutComplete = false;
-  late AudioPlayer player;
+  late AudioService player;
 
   @override
   void initState() {
     _exercises = widget.exercises;
     _currentIndex = 0;
-    player = AudioPlayer();
+    player = TimerAudioService("audio/exercise_change.mp3");
     initAudioPlayer();
     super.initState();
   }
 
   Future<void> initAudioPlayer() async {
-    await player.setAudioContext(AudioContext(
-      android: AudioContextAndroid(
-        usageType: AndroidUsageType.notification, 
-				audioFocus: AndroidAudioFocus.gainTransientMayDuck
-			),
-      iOS: AudioContextIOS(
-        category: AVAudioSessionCategory.playback, 
-				options: {AVAudioSessionOptions.mixWithOthers}
-			)
-		));
+    await player.configure();
   }
 
   void nextExercise(_) {

--- a/lib/state/workout_provider.dart
+++ b/lib/state/workout_provider.dart
@@ -16,12 +16,28 @@ class _WorkoutProviderState extends State<WorkoutProvider> {
   List<Exercise> _exercises = [];
   int _currentIndex = 0;
   bool _isWorkoutComplete = false;
+  late AudioPlayer player;
 
   @override
   void initState() {
     _exercises = widget.exercises;
     _currentIndex = 0;
+    player = AudioPlayer();
+    initAudioPlayer();
     super.initState();
+  }
+
+  Future<void> initAudioPlayer() async {
+    await player.setAudioContext(AudioContext(
+      android: AudioContextAndroid(
+        usageType: AndroidUsageType.notification, 
+				audioFocus: AndroidAudioFocus.gainTransientMayDuck
+			),
+      iOS: AudioContextIOS(
+        category: AVAudioSessionCategory.playback, 
+				options: {AVAudioSessionOptions.mixWithOthers}
+			)
+		));
   }
 
   void nextExercise(_) {
@@ -70,7 +86,7 @@ class _WorkoutProviderState extends State<WorkoutProvider> {
                 previousExercise: previousExercise,
                 noOfExercises: _exercises.length - 1,
                 workoutProgress: "${_currentIndex + 1}/${_exercises.length}",
-                player: AudioPlayer(),
+						player: player,
               ));
   }
 }

--- a/test/services/mock_audio_service.dart
+++ b/test/services/mock_audio_service.dart
@@ -1,0 +1,43 @@
+import 'package:count_up/services/audio_service.dart';
+
+class MockAudioService extends AudioService {
+  bool configured = false;
+
+  AudioStatus _status = AudioStatus.stopped;
+
+  @override
+  Future<void> configure() async {
+    configured = true;
+  }
+
+  @override
+  Future<void> play() async {
+    _status = AudioStatus.playing;
+  }
+
+  @override
+  Future<void> pause() async {
+    _status = AudioStatus.paused;
+  }
+
+  @override
+  Future<void> resume() async {
+    _status = AudioStatus.playing;
+  }
+
+  @override
+  Future<void> stop() async {
+    _status = AudioStatus.stopped;
+  }
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  AudioStatus get status => _status;
+
+  @override
+  set status(AudioStatus value) {
+    _status = value;
+  }
+}

--- a/test/state/timer_provider_test.dart
+++ b/test/state/timer_provider_test.dart
@@ -1,60 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:audioplayers/audioplayers.dart';
 import 'package:count_up/state/timer_provider.dart';
+import 'package:count_up/services/audio_service.dart';
 
-class FakeAudioPlayer extends AudioPlayer {
-  bool soundPlayed = false;
-
-  @override
-  Future<void> play(
-    Source source, {
-    double? volume,
-    double? balance,
-    AudioContext? ctx,
-    Duration? position,
-    PlayerMode? mode,
-  }) async {
-    soundPlayed = true;
-    return Future.value();
-  }
-}
+import '../services/mock_audio_service.dart';
 
 void main() {
-  late FakeAudioPlayer fakeAudioPlayer;
-  TestWidgetsFlutterBinding.ensureInitialized();
-
-  const MethodChannel audioplayersGlobal = MethodChannel('xyz.luan/audioplayers.global');
-  const MethodChannel audioPlayers = MethodChannel('xyz.luan/audioplayers');
-
-  setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(audioplayersGlobal,
-        (MethodCall methodCall) async {
-      switch (methodCall.method) {
-        case 'init':
-        default:
-          return null;
-      }
-    });
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(audioPlayers,
-        (MethodCall methodCall) async {
-      switch (methodCall.method) {
-        case 'create':
-        default:
-          return null;
-      }
-    });
-
-    fakeAudioPlayer = FakeAudioPlayer();
-  });
-
-  tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(audioplayersGlobal, null);
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(audioPlayers, null);
-  });
+  MockAudioService mockPlayer = MockAudioService();
 
   Widget createWidgetUnderTest(Duration duration, {Key? key}) {
     return MaterialApp(
@@ -67,7 +19,7 @@ void main() {
         noOfExercises: 1,
         nextExercise: (_) {},
         previousExercise: (_) {},
-        player: fakeAudioPlayer,
+        player: mockPlayer,
         workoutProgress: '1/1',
       ),
     ));
@@ -107,9 +59,8 @@ void main() {
     Widget testWidget = createWidgetUnderTest(Duration(seconds: 5), key: timerProviderKey);
     await tester.pumpWidget(testWidget);
     await tester.pump(Duration(seconds: 1));
-    final FakeAudioPlayer ac = timerProviderKey.currentState!.widget.player as FakeAudioPlayer;
-    expect(ac.soundPlayed, false); // Ensure no sound played yet
+    expect(mockPlayer.status, AudioStatus.stopped); // Ensure no sound played yet
     await tester.pump(Duration(seconds: 1));
-    expect(ac.soundPlayed, true); // Ensure sound played
+    expect(mockPlayer.status, AudioStatus.playing); // Ensure sound played
   });
 }


### PR DESCRIPTION
After `audioplayers` version upgrade, timer end sound always paused external sounds like Spotify, etc., which was undesirable. 

This PR fixes it by setting the player context to have `audioFocus: AndroidAudioFocus.gainTransientMayDuck` for Android.
Currently no explicit context has been set for iOS since app is only built for Android.